### PR TITLE
Added chat-notify workflow to .github directory

### DIFF
--- a/.github/workflows/chat-notify.yml
+++ b/.github/workflows/chat-notify.yml
@@ -14,18 +14,15 @@ jobs:
     # 実行環境
     runs-on: ubuntu-latest
     steps:
-      # Google Chatへの通知を行うための便利なアクション（他者作成）を利用
       - name: Send notification to Google Chat
-        uses: Co-qn/google-chat-notification@releases/v1
-        with:
-          # GitHubのSecretに保存したWebhook URLを安全に呼び出す
-          webhook_url: ${{ secrets.CHAT_WEBHOOK_URL }}
-          # ジョブのステータス（成功: success, 失敗: failureなど）
-          status: ${{ job.status }}
-          # 送信するメッセージ本文
-          message: |
-            課題が提出されました！
-            リポジトリ: ${{ github.repository }}
-            ブランチ: `${{ github.ref_name }}`
-            提出者: `${{ github.actor }}`
-            コミットを確認: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+        run: |
+          curl -X POST \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "text": "課題が提出されました！\n
+              リポジトリ: ${{ github.repository }}\n
+              ブランチ: `${{ github.ref_name }}`\n
+              提出者: `${{ github.actor }}`\n
+              コミットを確認: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+            }' \
+            "${{ secrets.CHAT_WEBHOOK_URL }}"


### PR DESCRIPTION
Githubのmainブランチ以外にプッシュがあった場合、Google Chatへ通知が来るようなGithub Actionsの設定を行いました。